### PR TITLE
Allows setting Unit type for the empty content (204, 205)

### DIFF
--- a/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/EitherCallAdapterFactory.kt
+++ b/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/EitherCallAdapterFactory.kt
@@ -59,8 +59,14 @@ public class EitherCallAdapterFactory private constructor(
         checkLeftIsThrowable(callType)
 
         val resultType = getParameterUpperBound(1, callType as ParameterizedType)
-        return EitherCallAdapter(resultType, coroutineScope)
+        val paramType = getRawType(resultType)
+        return EitherCallAdapter(
+          resultType = resultType,
+          paramType = paramType,
+          coroutineScope = coroutineScope
+        )
       }
+
       Deferred::class.java -> {
         val callType = getParameterUpperBound(0, returnType as ParameterizedType)
         val rawType = getRawType(callType)
@@ -71,7 +77,12 @@ public class EitherCallAdapterFactory private constructor(
         checkLeftIsThrowable(callType)
 
         val resultType = getParameterUpperBound(1, callType as ParameterizedType)
-        return EitherDeferredCallAdapter<Any>(resultType, coroutineScope)
+        val paramType = getRawType(resultType)
+        return EitherDeferredCallAdapter<Any>(
+          resultType = resultType,
+          paramType = paramType,
+          coroutineScope = coroutineScope
+        )
       }
       else -> return null
     }

--- a/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/internals/EitherCallAdapter.kt
+++ b/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/internals/EitherCallAdapter.kt
@@ -33,12 +33,13 @@ import java.lang.reflect.Type
  */
 internal class EitherCallAdapter(
   private val resultType: Type,
+  private val paramType: Type,
   private val coroutineScope: CoroutineScope
 ) : CallAdapter<Type, Call<Either<Throwable, Type>>> {
 
   override fun responseType(): Type = resultType
 
   override fun adapt(call: Call<Type>): Call<Either<Throwable, Type>> {
-    return EitherCall(call, coroutineScope)
+    return EitherCall(call, paramType, coroutineScope)
   }
 }

--- a/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/internals/EitherDeferredCallAdapter.kt
+++ b/retrofit-adapters-arrow/src/main/kotlin/com/skydoves/retrofit/adapters/arrow/internals/EitherDeferredCallAdapter.kt
@@ -38,6 +38,7 @@ import java.lang.reflect.Type
  */
 internal class EitherDeferredCallAdapter<T> constructor(
   private val resultType: Type,
+  private val paramType: Type,
   private val coroutineScope: CoroutineScope
 ) : CallAdapter<T, Deferred<Either<Throwable, T>>> {
 
@@ -58,7 +59,7 @@ internal class EitherDeferredCallAdapter<T> constructor(
 
       val response = call.awaitResponse()
       try {
-        val either = response.toEither(call)
+        val either = response.toEither(call, paramType)
         deferred.complete(either)
       } catch (e: Exception) {
         val either = e.left()

--- a/retrofit-adapters-arrow/src/test/kotlin/com/skydoves/retrofit/adapters/arrow/EitherCallTest.kt
+++ b/retrofit-adapters-arrow/src/test/kotlin/com/skydoves/retrofit/adapters/arrow/EitherCallTest.kt
@@ -20,6 +20,7 @@ import com.skydoves.retrofit.adapters.test.ApiMockServiceTest
 import com.skydoves.retrofit.adapters.test.MainCoroutinesRule
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
@@ -27,7 +28,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import retrofit2.Retrofit
 import retrofit2.awaitResponse
+import retrofit2.converter.moshi.MoshiConverterFactory
 
 @RunWith(JUnit4::class)
 internal class EitherCallTest : ApiMockServiceTest<PokemonService>() {
@@ -35,11 +38,12 @@ internal class EitherCallTest : ApiMockServiceTest<PokemonService>() {
   @get:Rule
   val coroutinesRule = MainCoroutinesRule()
 
+  private val testScope = TestScope(coroutinesRule.testDispatcher)
+
   private lateinit var service: PokemonService
 
   @Before
   fun initService() {
-    val testScope = TestScope(coroutinesRule.testDispatcher)
     service = createService(PokemonService::class.java, EitherCallAdapterFactory.create(testScope))
   }
 
@@ -54,6 +58,38 @@ internal class EitherCallTest : ApiMockServiceTest<PokemonService>() {
     assertThat(data.count, `is`(964))
     assertThat(data.results[0].name, `is`("bulbasaur"))
     assertThat(data.results[0].url, `is`("https://pokeapi.co/api/v2/pokemon/1/"))
+  }
+
+  @Test
+  fun `fetch items as Either type suspend function with error`() = runTest {
+    val retrofit: Retrofit = Retrofit.Builder()
+      .baseUrl(mockWebServer.url("/"))
+      .addConverterFactory(MoshiConverterFactory.create())
+      .addCallAdapterFactory(EitherCallAdapterFactory.create(testScope))
+      .build()
+
+    val service = retrofit.create(PokemonService::class.java)
+    mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("foo"))
+
+    val response = service.fetchPokemonList()
+    assertThat(response.isRight(), `is`(false))
+    assertThat(response.isLeft(), `is`(true))
+  }
+
+  @Test
+  fun `fetch items as Either type suspend function with empty body`() = runTest {
+    val retrofit: Retrofit = Retrofit.Builder()
+      .baseUrl(mockWebServer.url("/"))
+      .addConverterFactory(MoshiConverterFactory.create())
+      .addCallAdapterFactory(EitherCallAdapterFactory.create(testScope))
+      .build()
+
+    val service = retrofit.create(PokemonService::class.java)
+    mockWebServer.enqueue(MockResponse().setResponseCode(204).setBody(""))
+
+    val response = service.fetchPokemonListEmptyBody()
+    assertThat(response.isRight(), `is`(true))
+    assertThat(response.orNull(), `is`(Unit))
   }
 
   @Test

--- a/retrofit-adapters-arrow/src/test/kotlin/com/skydoves/retrofit/adapters/arrow/PokemonService.kt
+++ b/retrofit-adapters-arrow/src/test/kotlin/com/skydoves/retrofit/adapters/arrow/PokemonService.kt
@@ -35,4 +35,7 @@ internal interface PokemonService {
     @Query("limit") limit: Int = 20,
     @Query("offset") offset: Int = 0
   ): Call<Either<Throwable, PokemonResponse>>
+
+  @GET("pokemon")
+  suspend fun fetchPokemonListEmptyBody(): Either<Throwable, Unit>
 }

--- a/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/ResultCallAdapterFactory.kt
+++ b/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/ResultCallAdapterFactory.kt
@@ -57,8 +57,14 @@ public class ResultCallAdapterFactory private constructor(
         }
 
         val resultType = getParameterUpperBound(0, callType as ParameterizedType)
-        return ResultCallAdapter(resultType, coroutineScope)
+        val paramType = getRawType(resultType)
+        return ResultCallAdapter(
+          resultType = resultType,
+          paramType = paramType,
+          coroutineScope = coroutineScope
+        )
       }
+
       Deferred::class.java -> {
         val callType = getParameterUpperBound(0, returnType as ParameterizedType)
         val rawType = getRawType(callType)
@@ -67,7 +73,12 @@ public class ResultCallAdapterFactory private constructor(
         }
 
         val resultType = getParameterUpperBound(0, callType as ParameterizedType)
-        return ResultDeferredCallAdapter<Any>(resultType, coroutineScope)
+        val paramType = getRawType(resultType)
+        return ResultDeferredCallAdapter<Any>(
+          resultType = resultType,
+          paramType = paramType,
+          coroutineScope = coroutineScope
+        )
       }
       else -> return null
     }

--- a/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultCallAdapter.kt
+++ b/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultCallAdapter.kt
@@ -32,12 +32,13 @@ import java.lang.reflect.Type
  */
 internal class ResultCallAdapter(
   private val resultType: Type,
+  private val paramType: Type,
   private val coroutineScope: CoroutineScope
 ) : CallAdapter<Type, Call<Result<Type>>> {
 
   override fun responseType(): Type = resultType
 
   override fun adapt(call: Call<Type>): Call<Result<Type>> {
-    return ResultCall(call, coroutineScope)
+    return ResultCall(call, paramType, coroutineScope)
   }
 }

--- a/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultDeferredCallAdapter.kt
+++ b/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultDeferredCallAdapter.kt
@@ -36,6 +36,7 @@ import java.lang.reflect.Type
  */
 internal class ResultDeferredCallAdapter<T> constructor(
   private val resultType: Type,
+  private val paramType: Type,
   private val coroutineScope: CoroutineScope
 ) : CallAdapter<T, Deferred<Result<T>>> {
 
@@ -56,7 +57,7 @@ internal class ResultDeferredCallAdapter<T> constructor(
     coroutineScope.launch {
       try {
         val response = call.awaitResponse()
-        val result = response.toResult(call)
+        val result = response.toResult(call, paramType)
         deferred.complete(result)
       } catch (e: Exception) {
         val result = Result.failure<T>(e)

--- a/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultExtension.kt
+++ b/retrofit-adapters-result/src/main/kotlin/com/skydoves/retrofit/adapters/result/internals/ResultExtension.kt
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+@file:Suppress("UNCHECKED_CAST")
+
 package com.skydoves.retrofit.adapters.result.internals
 
 import retrofit2.Call
 import retrofit2.HttpException
 import retrofit2.Invocation
 import retrofit2.Response
+import java.lang.reflect.Type
 
 /**
  * @author skydoves (Jaewoong Eum)
@@ -27,23 +30,24 @@ import retrofit2.Response
  *
  * Returns [Result] from the [Response] instance and [Call] interface.
  */
-internal fun <T> Response<T>.toResult(call: Call<T>): Result<T> {
+internal fun <T> Response<T>.toResult(call: Call<T>, paramType: Type): Result<T> {
   return kotlin.runCatching {
     if (isSuccessful) {
-      val body = body()
-      if (body == null) {
-        val invocation = call.request().tag(Invocation::class.java)!!
-        val method = invocation.method()
-        throw KotlinNullPointerException(
-          "Response from " +
-            method.declaringClass.name +
-            '.' +
-            method.name +
-            " was null but response body type was declared as non-null"
-        )
-      } else {
-        body
-      }
+      body()
+        // You can confine the response type to Unit if you need to handle empty body, e.g, 204 No content.
+        ?: if (paramType == Unit::class.java) {
+          Unit as T
+        } else {
+          val invocation = call.request().tag(Invocation::class.java)!!
+          val method = invocation.method()
+          throw KotlinNullPointerException(
+            "Response from " +
+              method.declaringClass.name +
+              '.' +
+              method.name +
+              " was null but response body type was declared as non-null"
+          )
+        }
     } else {
       throw HttpException(this)
     }

--- a/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/PokemonService.kt
+++ b/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/PokemonService.kt
@@ -34,4 +34,7 @@ internal interface PokemonService {
     @Query("limit") limit: Int = 20,
     @Query("offset") offset: Int = 0
   ): Call<Result<PokemonResponse>>
+
+  @GET("pokemon")
+  suspend fun fetchPokemonListEmptyBody(): Result<Unit>
 }

--- a/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/ResultCallTest.kt
+++ b/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/ResultCallTest.kt
@@ -20,6 +20,7 @@ import com.skydoves.retrofit.adapters.test.ApiMockServiceTest
 import com.skydoves.retrofit.adapters.test.MainCoroutinesRule
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
@@ -27,7 +28,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import retrofit2.Retrofit
 import retrofit2.awaitResponse
+import retrofit2.converter.moshi.MoshiConverterFactory
 
 @RunWith(JUnit4::class)
 internal class ResultCallTest : ApiMockServiceTest<PokemonService>() {
@@ -35,11 +38,12 @@ internal class ResultCallTest : ApiMockServiceTest<PokemonService>() {
   @get:Rule
   val coroutinesRule = MainCoroutinesRule()
 
+  private val testScope = TestScope(coroutinesRule.testDispatcher)
+
   private lateinit var service: PokemonService
 
   @Before
   fun initService() {
-    val testScope = TestScope(coroutinesRule.testDispatcher)
     service = createService(PokemonService::class.java, ResultCallAdapterFactory.create(testScope))
   }
 
@@ -47,23 +51,55 @@ internal class ResultCallTest : ApiMockServiceTest<PokemonService>() {
   fun `fetch items as Result type with suspend function successfully`() = runTest {
     enqueueResponse("/PokemonResponse.json")
 
-    val response = service.fetchPokemonList()
-    assertThat(response.isSuccess, `is`(true))
+    val result = service.fetchPokemonList()
+    assertThat(result.isSuccess, `is`(true))
 
-    val data = response.getOrNull()!!
+    val data = result.getOrNull()!!
     assertThat(data.count, `is`(964))
     assertThat(data.results[0].name, `is`("bulbasaur"))
     assertThat(data.results[0].url, `is`("https://pokeapi.co/api/v2/pokemon/1/"))
   }
 
   @Test
+  fun `fetch items as Result type suspend function with error`() = runTest {
+    val retrofit: Retrofit = Retrofit.Builder()
+      .baseUrl(mockWebServer.url("/"))
+      .addConverterFactory(MoshiConverterFactory.create())
+      .addCallAdapterFactory(ResultCallAdapterFactory.create(testScope))
+      .build()
+
+    val service = retrofit.create(PokemonService::class.java)
+    mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("foo"))
+
+    val result = service.fetchPokemonList()
+    assertThat(result.isSuccess, `is`(false))
+    assertThat(result.isSuccess, `is`(false))
+  }
+
+  @Test
+  fun `fetch items as Result type suspend function with empty body`() = runTest {
+    val retrofit: Retrofit = Retrofit.Builder()
+      .baseUrl(mockWebServer.url("/"))
+      .addConverterFactory(MoshiConverterFactory.create())
+      .addCallAdapterFactory(ResultCallAdapterFactory.create(testScope))
+      .build()
+
+    val service = retrofit.create(PokemonService::class.java)
+    mockWebServer.enqueue(MockResponse().setResponseCode(204).setBody(""))
+
+    val result = service.fetchPokemonListEmptyBody()
+    assertThat(result.isSuccess, `is`(true))
+    assertThat(result.getOrNull(), `is`(Unit))
+  }
+
+  @Test
   fun `fetch items as Call type of Result successfully`() = runTest {
     enqueueResponse("/PokemonResponse.json")
 
-    val response = service.fetchPokemonListAsCall().awaitResponse().body()!!
-    assertThat(response.isSuccess, `is`(true))
+    val result = service.fetchPokemonListAsCall().awaitResponse().body()!!
+    assertThat(result.isSuccess, `is`(true))
 
-    val data = response.getOrNull()!!
+    val data = result.getOrNull()!!
     assertThat(data.count, `is`(964))
     assertThat(data.results[0].name, `is`("bulbasaur"))
     assertThat(data.results[0].url, `is`("https://pokeapi.co/api/v2/pokemon/1/"))

--- a/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/ResultCallTest.kt
+++ b/retrofit-adapters-result/src/test/kotlin/com/skydoves/retrofit/adapters/result/ResultCallTest.kt
@@ -73,7 +73,6 @@ internal class ResultCallTest : ApiMockServiceTest<PokemonService>() {
 
     val result = service.fetchPokemonList()
     assertThat(result.isSuccess, `is`(false))
-    assertThat(result.isSuccess, `is`(false))
   }
 
   @Test

--- a/retrofit-adapters-test/src/main/kotlin/com/skydoves/retrofit/adapters/test/ApiMockServiceTest.kt
+++ b/retrofit-adapters-test/src/main/kotlin/com/skydoves/retrofit/adapters/test/ApiMockServiceTest.kt
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets
 @RunWith(JUnit4::class)
 public abstract class ApiMockServiceTest<T> {
 
-  private lateinit var mockWebServer: MockWebServer
+  public lateinit var mockWebServer: MockWebServer
 
   @Before
   public fun mockServer() {


### PR DESCRIPTION
Allows setting Unit type for the empty content (204. 205).

```kotlin
@GET("/users/info")
suspend fun updateUserInfo(userRequest: UserRequest): Result<Unit>
```