### PR TITLE
Update nexus maven plugin to 1.3.0 and and binary compatibility validator

### DIFF
--- a/buildSrc/src/main/kotlin/com/skydoves/retrofit/adapters/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/retrofit/adapters/Dependencies.kt
@@ -3,11 +3,11 @@ package com.skydoves.retrofit.adapters
 object Versions {
   internal const val ANDROID_GRADLE_PLUGIN = "7.4.0"
   internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
-  internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
+  internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.3.0"
   internal const val KOTLIN = "1.8.10"
   internal const val KOTLIN_SERIALIZATION_JSON = "1.4.0"
   internal const val KOTLIN_GRADLE_DOKKA = "1.7.20"
-  internal const val KOTLIN_BINARY_VALIDATOR = "0.12.1"
+  internal const val KOTLIN_BINARY_VALIDATOR = "0.13.0"
 
   internal const val RETROFIT = "2.9.0"
   internal const val OKHTTP = "4.10.0"


### PR DESCRIPTION
## Guidelines
Update nexus maven plugin to 1.3.0 and binary compatibility validator.